### PR TITLE
ci: exclude sonar scans for Dependabot PR's

### DIFF
--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+    branches:
+      - '!integration/dependabot'
 jobs:
   sonarcloud:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR's triggered by Dependabot, have no access to our CI secrets and can therefore not properly start the Sonar scan workflow. To me, it seems the best (most efficient) approve to skip Sonar scans on Dependabot PR's.